### PR TITLE
Use models plural name instead of pluralize

### DIFF
--- a/app/models/concerns/slickr/previewable.rb
+++ b/app/models/concerns/slickr/previewable.rb
@@ -11,7 +11,7 @@ module Slickr
       private
 
       def slickr_previewable(opts = {})
-        options = { preview_enabled: true, layout: 'layouts/application', template: "#{self.name.pluralize.underscore.downcase}/show", locals: {} }.merge(opts)
+        options = { preview_enabled: true, layout: 'layouts/application', template: "#{self.model_name.plural}/show", locals: {} }.merge(opts)
         @slickr_previewable_opts = options
       end
     end


### PR DESCRIPTION
This will allow resources to have the correct template directory used in preview in the case that the resource has a custom plural defined in the app.