### PR TITLE
Updates for image uploader/resizer for project migrations

### DIFF
--- a/app/jobs/resize_images_job.rb
+++ b/app/jobs/resize_images_job.rb
@@ -25,6 +25,9 @@ class ResizeImagesJob < ApplicationJob
       when :fit
         attacher.add_derivative(thumb_name,
           pipeline.resize_to_fit(*options[:options]).call)
+      when :pad
+        attacher.add_derivative(thumb_name,
+          pipeline.resize_and_pad(*options[:options]).call)
       end
     end
 
@@ -33,7 +36,7 @@ class ResizeImagesJob < ApplicationJob
 
   def available_derivatives
     Slickr::MediaUpload::DEFAULT_IMAGE_DERIVATIVES.merge(
-      Slickr::MediaUpload::ADDITIONAL_DERIVATIVES
+      Slickr::MediaUpload.additional_derivatives
     )
   end
 end

--- a/app/models/slickr/media_upload.rb
+++ b/app/models/slickr/media_upload.rb
@@ -5,8 +5,6 @@ module Slickr
     self.table_name = 'slickr_media_uploads'
     DROP_AREA_TEXT = 'Maximum size 10Mb | .jpeg, .jpg, .png and .pdf files only'
 
-    ADDITIONAL_DERIVATIVES = {}
-
     DEFAULT_IMAGE_DERIVATIVES = {
       square: {
         square_2400: {
@@ -100,6 +98,17 @@ module Slickr
         },
         content_400: {
           type: :limit, options: [400, nil]
+        }
+      },
+      thumb: {
+        thumb_800x800: {
+          type: :pad, options: [800, 800, { extend: :white }]
+        },
+        thumb_400x400: {
+          type: :pad, options: [400, 400, { extend: :white }]
+        },
+        thumb_200x200: {
+          type: :pad, options: [200, 200, { extend: :white }]
         }
       }
     }
@@ -208,6 +217,14 @@ module Slickr
       }
     end
 
+    def add_new_derivatives(key)
+      ResizeImagesJob.perform_later(self, key)
+    end
+
+    def self.additional_derivatives
+      {}
+    end
+
     private
 
     def build_file
@@ -264,10 +281,6 @@ module Slickr
       ResizeImagesJob.perform_later(self, :landscape)
       ResizeImagesJob.perform_later(self, :panoramic)
       ResizeImagesJob.perform_later(self, :content)
-    end
-
-    def add_new_derivatives(key)
-      ResizeImagesJob.perform_later(self, key)
     end
   end
 end


### PR DESCRIPTION
- additional_derivatives now a class method so its easier to override per-projects without including the entire class. I could not for the life of me override a class constant, but it was a breeze to update it as a class method. 
- add thumbnails to base config and job options
- make add_new_derivative method public