### PR TITLE
Add missing activity owner handling

### DIFF
--- a/app/views/layouts/_activity.html.erb
+++ b/app/views/layouts/_activity.html.erb
@@ -8,13 +8,13 @@
       %>
     </header>
     <section class="dashboard__events-item__content">
-      <% if activity.owner.admin_user_avatar %>
+      <% if activity.owner.present? && activity.owner.admin_user_avatar %>
         <%= image_tag activity.owner.admin_user_avatar.image_url(:thumb_fill), class: "dashboard__events-item__avatar display_avatar" %>
       <% end %>
       <%= t("action_html".to_sym,
         scope: [:activerecord, :models, :event_log, :eventable, :actions],
         action: Verbs::Conjugator.conjugate(activity.key.split('.').last, :tense => :past, :aspect => :perfective),
-        user: activity.owner.display_name,
+        user: activity.owner.present? ? activity.owner.display_name : 'User Removed',
         class: activity.trackable ? activity.trackable.class.name.downcase.gsub("slickr::", "") : activity.parameters[:type].downcase)
       %>
       <%= yield %>


### PR DESCRIPTION
It should stop the dashboard from breaking when the AdminUser assigned as the activity owner is removed.