### PR TITLE
Updates to restorable and trackable

### DIFF
--- a/app/models/concerns/slickr/restorable.rb
+++ b/app/models/concerns/slickr/restorable.rb
@@ -6,6 +6,8 @@ module Slickr
     extend ActiveSupport::Concern
     include Discard::Model
 
+    default_scope { kept }
+
     module ClassMethods
       attr_reader :slickr_restorable_opts
 

--- a/app/models/slickr/page.rb
+++ b/app/models/slickr/page.rb
@@ -19,12 +19,12 @@ module Slickr
     include PublicActivity::Model
     tracked(
       on: {
-        create: proc {|model, controller| model.class.name != 'Slickr::Page::Draft' },
-        update: proc {|model, controller| model.class.name != 'Slickr::Page::Draft' },
-        destroy: proc {|model, controller| model.class.name != 'Slickr::Page::Draft' }
+        create: proc { |model, _controller| model.class.name != 'Slickr::Page::Draft' },
+        update: proc { |model, _controller| model.class.name != 'Slickr::Page::Draft' },
+        destroy: proc { |model, _controller| model.class.name != 'Slickr::Page::Draft' }
       },
       params: { title: :title, type: 'Page' },
-      owner: proc { |controller, model| controller.current_admin_user }
+      owner: proc { |controller, _model| controller&.current_admin_user }
     )
 
     has_paper_trail only: %i[title aasm_state content published_content drafts]

--- a/app/models/slickr/page.rb
+++ b/app/models/slickr/page.rb
@@ -12,6 +12,9 @@ module Slickr
     include Slickr::Restorable
     include AASM
     slickr_restorable
+    after_discard do
+      slickr_navigations.destroy_all
+    end
 
     include PublicActivity::Model
     tracked(

--- a/app/models/slickr/rubbish.rb
+++ b/app/models/slickr/rubbish.rb
@@ -8,7 +8,7 @@ module Slickr
     def self.add_restorable(restorable)
       @@restorable_classes << restorable
       Slickr::Rubbish.define_singleton_method(restorable[:restorable_method]) do
-        restorable[:restorable_model].name.classify.constantize.discarded
+        restorable[:restorable_model].name.classify.constantize.unscoped(:discarded)
       end
     end
 
@@ -18,7 +18,7 @@ module Slickr
 
     @@restorable_classes.each do |restorable|
       Slickr::Rubbish.define_singleton_method(restorable[:restorable_method]) do
-        restorable[:restorable_model].name.classify.discarded
+        restorable[:restorable_model].name.classify.unscoped(:discarded)
       end
     end
   end

--- a/app/services/slickr/navigation_builder.rb
+++ b/app/services/slickr/navigation_builder.rb
@@ -83,7 +83,7 @@ module Slickr
     def build_page_pathnames(hash, pathname, array)
       if hash['child_type'] == 'Page'
         if hash['schedule_time'].nil?
-          new_pathname = pathname + hash['slug']
+          new_pathname = pathname + hash['slug'].to_s
           array.push(page_id: hash['page_id'], path: new_pathname)
           hash['children'].map do |child_hash|
             build_page_pathnames(child_hash, "#{new_pathname}/", array)

--- a/lib/slickr/version.rb
+++ b/lib/slickr/version.rb
@@ -1,3 +1,3 @@
 module Slickr
-  VERSION = '0.22.5'
+  VERSION = '0.22.6'
 end


### PR DESCRIPTION
Adding a controversial default_scope. This is a perf example to use it, where exposing 'deleted' content is explicit and hiding it is implicit.

For slickr_pages, remove navigation items on discard.

Update trackable to prevent breaking when creating Pages outside of controller action